### PR TITLE
Unset fontSize and fontFamily

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,6 @@ exports.decorateConfig = config => {
     foregroundColor,
     borderColor: '#D8DBE2',
     cursorColor: '#D8DBE2',
-    fontSize:14,
-    fontFamily:'Fira Code, Menlo, DejaVu Sans Mono, Lucida Console, monospace',
     colors: [
       black,
       red,


### PR DESCRIPTION
Hi 👋,

I really like using this theme, thank you for making it. However there's a different font I like using in my terminal and wanted to offer up this PR as a way to let users decide which font to use with the theme. In my use of hyperterm v0.7.1.36 having `fontFamily` and `fontSize` set in the theme override my personal settings.

Thanks!
